### PR TITLE
fix(SF-1096): Mix in the product on init instead of before-mount

### DIFF
--- a/src/product/index.ts
+++ b/src/product/index.ts
@@ -30,7 +30,7 @@ class Product {
     },
   };
 
-  onBeforeMount() {
+  init() {
     this.state = { ...this.state, ...this.props.product };
   }
 

--- a/test/unit/product.ts
+++ b/test/unit/product.ts
@@ -120,12 +120,12 @@ suite('Product', ({ expect, spy, itShouldProvideAlias }) => {
     });
   });
 
-  describe('onBeforeMount()', () => {
+  describe('init()', () => {
     it('should mixin product to state', () => {
       product.props = <any>{ product: { a: 'b' } };
       product.state = <any>{ c: 'd' };
 
-      product.onBeforeMount();
+      product.init();
 
       expect(product.state).to.eql({ a: 'b', c: 'd' });
     });


### PR DESCRIPTION
The alias is not updated after before-mount is run, so the mixin must be done in init.